### PR TITLE
Replace bit.ly links with direct URLs

### DIFF
--- a/R/summary_tab_module.R
+++ b/R/summary_tab_module.R
@@ -97,11 +97,11 @@ summary_tab_server <- function(id) {
           </a></cite>, and further developed in subsequent publications by
           <cite>
           <a href=
-          'http://bit.ly/40W7wQY'>
+          'https://www.sciencedirect.com/science/article/pii/S1755436514000371'>
           de Graaf (2014)</a></cite>,
           <cite>
           <a href=
-          'https://bit.ly/42UnBJv'>
+          'https://www.sciencedirect.com/science/article/pii/S1755436516300135'>
           Teunis (2016)</a></cite>, and <cite>
           <a href='https://onlinelibrary.wiley.com/doi/10.1002/sim.8578'>
           Teunis (2020)</a>.</cite></p>
@@ -124,7 +124,7 @@ summary_tab_server <- function(id) {
 
           <p>Further details on the methodology can be found on the
           <a href=
-          'https://bit.ly/41aaOBr'>
+          'https://ucd-serg.github.io/serocalculator/articles/serocalculator.html'>
           main package website</a>.</p>
 
           <p>This app provides a user-friendly interface to use the


### PR DESCRIPTION
## Summary

The summary tab's intro text (`R/summary_tab_module.R`) linked to two citations and the package website through `bit.ly` shorteners. This replaces them with their direct destination URLs so the links are transparent and don't depend on the bit.ly service staying alive.

| Old (bit.ly) | New (direct) |
|---|---|
| `http://bit.ly/40W7wQY` | `https://www.sciencedirect.com/science/article/pii/S1755436514000371` (de Graaf 2014) |
| `https://bit.ly/42UnBJv` | `https://www.sciencedirect.com/science/article/pii/S1755436516300135` (Teunis 2016) |
| `https://bit.ly/41aaOBr` | `https://ucd-serg.github.io/serocalculator/articles/serocalculator.html` (package website) |

Destinations were obtained by following each shortener's redirect; the tracking query suffix (`?via=ihub`) was dropped from the ScienceDirect URLs.

## Test plan

- `parse("R/summary_tab_module.R")` succeeds
- No `bit.ly` references remain in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)