### PR TITLE
Fix estimation calls for serocalculator 1.4.x API

### DIFF
--- a/R/estimate_seroincidence_module.R
+++ b/R/estimate_seroincidence_module.R
@@ -145,17 +145,17 @@ estimate_seroincidence_server <- function(id,
       )
       output$est_incidence <- renderTable({
         if (input$choose_stratification == "overall") {
-          est <- serocalculator::estimate_scr(
+          est <- serocalculator::est_seroincidence(
             pop_data = pop_df(),
-            curve_params = curve_df(),
+            sr_params = curve_df(),
             noise_params = noise_df(),
             antigen_isos = input$antigen_available,
             verbose = TRUE
           )
         } else if (input$choose_stratification == "stratified") {
-          est <- serocalculator::estimate_scr_by(
+          est <- serocalculator::est_seroincidence_by(
             pop_data = pop_df(),
-            curve_params = curve_df(),
+            sr_params = curve_df(),
             noise_params = noise_df(),
             verbose = TRUE,
             antigen_isos = input$antigen_available,


### PR DESCRIPTION
## Summary

`R/estimate_seroincidence_module.R` calls `serocalculator::estimate_scr()` / `estimate_scr_by()`, but those names **never shipped** in serocalculator. Per serocalculator's own [version-crosswalk doc](https://github.com/UCD-SERG/serocalculator/blob/main/vignettes/articles/version-crosswalk-1.3-to-1.4.qmd), `estimate_scr`/`estimate_scr_by` were short-lived intermediate dev names that were replaced before 1.4.0. The result: the app loads fine but **crashes on any estimation run** against installed serocalculator 1.4.1.

This switches to the real 1.4.x API:

| Stale (never shipped) | Correct 1.4.x |
|---|---|
| `estimate_scr()` | `est_seroincidence()` |
| `estimate_scr_by()` | `est_seroincidence_by()` |
| `curve_params =` | `sr_params =` |

(The `est.incidence` → `est_seroincidence` rename came in via #61; the `estimate_scr` naming is unrelated to the bit.ly PR #62.)

## Test plan

- `pkgload::load_all()` succeeds
- `est_seroincidence`, `est_seroincidence_by` confirmed present in installed serocalculator 1.4.1 with an `sr_params` argument
- App relaunched on shiny-server and serves HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)